### PR TITLE
Initial posix support

### DIFF
--- a/doc/platform_support.txt
+++ b/doc/platform_support.txt
@@ -4,9 +4,12 @@ dependent. These include:
 - The procedures that trick the compiler optimizer doNotOptimizeAway() and
   memoryClobber()
 This module has been tested on:
-- Windows 10/x86-64 with the
-  - MSVC compiler of Visual Studio 2013 (also called vcc sometimes)
+- Windows 10 / x86-64 with compilers:
+  - MSVC distributed with Visual Studio 2013 (also called vcc sometimes)
   - Mingw compiler distributed with Nim Version 0.13.0
+- Ubuntu 15.10 / x86 (in a VM) with compilers:
+  - clang 3.6.2
+  - gcc 5.2.1
 
 Porting to other platforms is not too much work, but it must be done
 correctly. This means that the resulting assembly code must be checked, to

--- a/nimbench.html
+++ b/nimbench.html
@@ -1262,8 +1262,12 @@ dummy                                                           0fs      inf</pr
 <li>The procedures that trick the compiler optimizer doNotOptimizeAway() and memoryClobber()</li>
 </ul>
 <p>This module has been tested on:</p>
-<ul class="simple"><li>Windows 10/x86-64 with the<ul class="simple"><li>MSVC compiler of Visual Studio 2013 (also called vcc sometimes)</li>
+<ul class="simple"><li>Windows 10 / x86-64 with compilers:<ul class="simple"><li>MSVC distributed with Visual Studio 2013 (also called vcc sometimes)</li>
 <li>Mingw compiler distributed with Nim Version 0.13.0</li>
+</ul>
+</li>
+<li>Ubuntu 15.10 / x86 (in a VM) with compilers:<ul class="simple"><li>clang 3.6.2</li>
+<li>gcc 5.2.1</li>
 </ul>
 </li>
 </ul>
@@ -1326,7 +1330,7 @@ Like doNotOptimizeAway() this template could come in handy when the compiler opt
       <div class="twelve-columns footer">
         <span class="nim-sprite"></span>
         <br/>
-        <small>Made with Nim. Generated: 2016-02-12 19:52:43 UTC</small>
+        <small>Made with Nim. Generated: 2016-02-13 15:20:11 UTC</small>
       </div>
     </div>
   </div>

--- a/nimbench/private/timers.nim
+++ b/nimbench/private/timers.nim
@@ -55,5 +55,15 @@ elif defined(macosx):
     var timebase: mach_timebase_info_data_t
     mach_timebase_info(timebase)
     result = time * int64(timebase.numer.float32 / timebase.denom.float32)
+elif defined(posix):
+  import posix
+  proc getTimeMeasurement*(): TimeMeasurement {.inline.} =
+    var timespec: Timespec
+    let success = clock_gettime(CLOCK_REALTIME, timespec)
+    if success != 0:
+      raise newException(OSError, "clock_gettime failed")
+    result = TimeMeasurement(int64(timespec.tv_sec) * 1_000_000_000'i64 +
+                             int64(timespec.tv_nsec))
+  proc `-`*(a, b: TimeMeasurement): NanoSeconds {.borrow.}
 else:
   {.fatal: "time measurement for this platform is not implemented yet!".}


### PR DESCRIPTION
Tested on ubuntu 32 bit in a virtual box VM. tested gcc 5.2.1 and clang 3.6.2.
Timing functions, doNotOptimizeAway and memoryClobber seem to work fine.
Ran the benchmark examples from the documentation.
Clang generates the same results as when testing on windows.
Only GCC seems to butcher the fpOps3 test with 10x slower code. The other benchmarks are fine. 

This does not seem to be caused by doNotOptimizeAway: I replaced it with a global variable to be increased and echoed at the end of the program with the same result. Wonder if the same thing happens on x64, however I currently don't have a machine to test it on. Maybe this is caused by running in a VM.

For now clang is recommended for ubuntu 32 bit.
